### PR TITLE
fix: renderButton passed correct prop

### DIFF
--- a/apps/www/content/docs/components/side-panel.mdx
+++ b/apps/www/content/docs/components/side-panel.mdx
@@ -77,7 +77,7 @@ export default function SidePanelExample() {
         <SidePanel
           panelOpen={isOpen}
           handlePanelOpen={handleIsOpen}
-          renderButton={renderVideoButton}
+          renderButton={renderOpenButton}
         >
           <div className="h-16 w-full">
             <div>Content Here</div>


### PR DESCRIPTION
In the usage section of the Side Panel docs the prop passed to the renderButton was `renderVideoButton` but it should be `renderOpenButton` as defined above.