### PR TITLE
fix(floating-panel): prevent title from stretching during layout animation

### DIFF
--- a/apps/www/registry/default/ui/floating-panel.tsx
+++ b/apps/www/registry/default/ui/floating-panel.tsx
@@ -238,7 +238,7 @@ function FloatingPanelTitle({ children }: FloatingPanelTitleProps) {
     >
       <motion.div
         layoutId={`floating-panel-label-${uniqueId}`}
-        className="text-sm font-semibold text-zinc-900 dark:text-zinc-100"
+        className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 w-fit"
         id={`floating-panel-title-${uniqueId}`}
       >
         {children}


### PR DESCRIPTION
### Fix: Floating Panel Title Animation

## **Before**
![original](https://github.com/user-attachments/assets/c01508ab-e1c9-4bc4-ac75-03bdd0a52503)


## **After**
![fix](https://github.com/user-attachments/assets/529ab077-837f-4ff3-9ef2-f361b68fb677)





