### PR TITLE
fix(examples): prevent layout overflow in youtube-video-player-demo

### DIFF
--- a/apps/www/registry/default/example/youtube-video-player-demo.tsx
+++ b/apps/www/registry/default/example/youtube-video-player-demo.tsx
@@ -4,7 +4,7 @@ import { YouTubePlayer } from "@/registry/default/ui/youtube-video-player"
 
 export default function YouTubeVideoPlayerDemo() {
   return (
-    <div className="space-y-12 p-8">
+    <div className="space-y-12 p-8 overflow-x-auto">
       <div className="space-y-4">
         <h1 className="text-3xl font-bold">YouTube Video Player Examples</h1>
         <p className="text-muted-foreground">


### PR DESCRIPTION
## Description
Fixes horizontal overflow issue in the YouTube Video Player demo page by adding `overflow-x-auto` to the container.

## Changes
- Added `overflow-x-auto` class to prevent layout breaking on smaller screens

## Demo
<!-- Add your GIFs/screenshots here -->
### Before
![before](https://github.com/user-attachments/assets/d9a854d8-bc55-4e93-83a1-ea72b30cd597)


### After  

![after](https://github.com/user-attachments/assets/0a14e973-f0b3-4295-8f99-9b029442b3cf)
