### PR TITLE
docs(code-block): clarify language prop to indicate it has no built-in syntax highlighting

### DIFF
--- a/apps/www/content/docs/components/code-block.mdx
+++ b/apps/www/content/docs/components/code-block.mdx
@@ -165,7 +165,7 @@ API_SECRET_KEY=your-secret-key`,
 | ----------- | ----------- | -------- | ------------------------------------------- |
 | `tabs`      | `CodeTab[]` | -        | Array of code tabs for multi-tab display    |
 | `code`      | `string`    | -        | Single code string (when not using tabs)    |
-| `language`  | `string`    | `"bash"` | Language identifier for syntax highlighting |
+| `language`  | `string`    | `"bash"` | Language label only (syntax highlighting is not built in) |
 | `className` | `string`    | -        | Additional CSS classes                      |
 
 ### CodeTab Interface
@@ -174,7 +174,7 @@ API_SECRET_KEY=your-secret-key`,
 | ---------- | -------- | ---------------------------------- |
 | `label`    | `string` | Tab label displayed in the tab bar |
 | `code`     | `string` | Code content for this tab          |
-| `language` | `string` | Optional language identifier       |
+| `language` | `string` | Optional language label (no built-in syntax highlighting) |
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Clarify `CodeBlock.language` docs to indicate that's a label only
- Clarify `CodeTab.language` docs to indicate syntax highlighting is not built in

## Why
The component does not implement syntax highlighting, so the previous sentence was misleading. I tried to use it, but there was no syntax highlighting and I was disappointed.