### PR TITLE
chore(ci): use console.error for error logging in version scripts

### DIFF
--- a/.github/version-script-beta.js
+++ b/.github/version-script-beta.js
@@ -9,7 +9,7 @@ try {
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath))
   exec("git rev-parse --short HEAD", (err, stdout) => {
     if (err) {
-      console.log(err)
+      console.error(err)
       process.exit(1)
     }
     pkg.version = "0.0.0-beta." + stdout.trim()

--- a/.github/version-script-next.js
+++ b/.github/version-script-next.js
@@ -9,7 +9,7 @@ try {
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath))
   exec("git rev-parse --short HEAD", (err, stdout) => {
     if (err) {
-      console.log(err)
+      console.error(err)
       process.exit(1)
     }
     pkg.version = "0.0.0-next." + stdout.trim()


### PR DESCRIPTION

# Description

- Changed error logging in two GitHub helper scripts to use `console.error` instead of `console.log` so that errors are emitted to stderr. 
- No behavioral change beyond correct logging stream. Files changed:

### Changed Files

- version-script-beta.js:
- version-script-next.js: